### PR TITLE
Set default encoding to utf-8 in vimrc

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,4 +1,5 @@
 " .vimrc
+set encoding=utf-8
 
 " load up pathogen and all bundles
 call pathogen#infect()


### PR DESCRIPTION
Fixes https://github.com/chrishunt/dot-files/issues/6
Thanks @dongbeta!

From the vim documentation:

> NOTE: For MacVim and GTK+ 2 it is highly recommended to set 'encoding' to "utf-8".  Although care has been taken to allow different values of 'encoding', "utf-8" is the natural choice for the environment and avoids unnecessary conversion overhead.
> 
> **"utf-8" has not been made the default to prevent different behavior of the GUI and terminal versions, and to avoid changing the encoding of newly created files without your knowledge** (in case 'fileencodings' is empty).
