### PR TITLE
Add a space before the tmux pane list

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -83,7 +83,7 @@ set -g status-justify left
 
 # show session, window, pane in left status bar
 set -g status-left-length 40
-set -g status-left '#[fg=green]#S#[fg=blue] #I:#P#[default]'
+set -g status-left '#[fg=green]#S#[fg=blue] #I:#P #[default]'
 
 # show hostname, date, time, and battery in right status bar
 set-option -g status-right '#[fg=green]#H#[default] %m/%d/%y %I:%M\


### PR DESCRIPTION
As [recommended](https://github.com/chrishunt/dot-files/commit/4b03eec27a18e92916903992a4e005137340de08#commitcomment-13699811) by @dgmstuart. Thank you!

Changes this:

![before](https://cloud.githubusercontent.com/assets/65323/10417361/7ec64838-6fed-11e5-9222-4ae7156057b3.jpg)

To this:

![after](https://cloud.githubusercontent.com/assets/65323/10417362/81d4f4fc-6fed-11e5-8f2b-ba2a12d323a9.jpg)